### PR TITLE
feat: 添加 PostgreSQL 数据库存储支持

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,18 @@ ADMIN_KEY=your-admin-secret-key
 # PORT=7860
 
 # ============================================
+# 数据库配置（可选，用于无持久化存储的环境如 HF Spaces）
+# ============================================
+# 支持 PostgreSQL 数据库存储账户配置
+# 未设置时使用本地文件存储（原有行为）
+#
+# 示例（Neon PostgreSQL）：
+# DATABASE_URL=postgresql://user:password@ep-xxx.aws.neon.tech/dbname?sslmode=require
+#
+# 注意：使用数据库存储需要安装 asyncpg：pip install asyncpg
+# DATABASE_URL=
+
+# ============================================
 # 其他配置请在管理面板的"系统设置"中配置
 # 包括：API密钥、代理、图片生成、重试策略等
 # 配置保存在 data/settings.yaml

--- a/core/account.py
+++ b/core/account.py
@@ -13,6 +13,9 @@ from typing import Dict, List, Optional, TYPE_CHECKING
 
 from fastapi import HTTPException
 
+# 导入存储层（支持数据库）
+from core import storage
+
 if TYPE_CHECKING:
     from core.jwt import JWTManager
 
@@ -313,16 +316,51 @@ class MultiAccountManager:
 
 # ---------- 配置文件管理 ----------
 
-def save_accounts_to_file(accounts_data: list):
-    """保存账户配置到文件"""
+def _save_to_file(accounts_data: list):
+    """保存账户配置到本地文件"""
+    os.makedirs(os.path.dirname(ACCOUNTS_FILE) or ".", exist_ok=True)
     with open(ACCOUNTS_FILE, 'w', encoding='utf-8') as f:
         json.dump(accounts_data, f, ensure_ascii=False, indent=2)
     logger.info(f"[CONFIG] 配置已保存到 {ACCOUNTS_FILE}")
 
 
+def _load_from_file() -> list:
+    """从本地文件加载账户配置"""
+    if os.path.exists(ACCOUNTS_FILE):
+        try:
+            with open(ACCOUNTS_FILE, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception as e:
+            logger.warning(f"[CONFIG] 文件加载失败: {str(e)}")
+    return None
+
+
+def save_accounts_to_file(accounts_data: list):
+    """保存账户配置（优先数据库，降级到文件）"""
+    # 尝试保存到数据库
+    if storage.is_database_enabled():
+        try:
+            import asyncio
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # 在已有事件循环中，创建任务
+                asyncio.create_task(storage.save_accounts(accounts_data))
+                logger.info(f"[CONFIG] 配置已提交到数据库（异步）")
+                return
+            else:
+                saved = loop.run_until_complete(storage.save_accounts(accounts_data))
+                if saved:
+                    return
+        except Exception as e:
+            logger.warning(f"[CONFIG] 数据库保存失败: {e}，降级到文件存储")
+    
+    # 降级到文件存储
+    _save_to_file(accounts_data)
+
+
 def load_accounts_from_source() -> list:
-    """从环境变量或文件加载账户配置，优先使用环境变量"""
-    # 优先从环境变量加载
+    """从环境变量、数据库或文件加载账户配置"""
+    # 1. 优先从环境变量加载
     env_accounts = os.environ.get('ACCOUNTS_CONFIG')
     if env_accounts:
         try:
@@ -333,24 +371,35 @@ def load_accounts_from_source() -> list:
                 logger.warning(f"[CONFIG] 环境变量 ACCOUNTS_CONFIG 为空")
             return accounts_data
         except Exception as e:
-            logger.error(f"[CONFIG] 环境变量加载失败: {str(e)}，尝试从文件加载")
+            logger.error(f"[CONFIG] 环境变量加载失败: {str(e)}")
 
-    # 从文件加载
-    if os.path.exists(ACCOUNTS_FILE):
+    # 2. 尝试从数据库加载
+    if storage.is_database_enabled():
         try:
-            with open(ACCOUNTS_FILE, 'r', encoding='utf-8') as f:
-                accounts_data = json.load(f)
-            if accounts_data:
-                logger.info(f"[CONFIG] 从文件加载配置: {ACCOUNTS_FILE}，共 {len(accounts_data)} 个账户")
-            else:
-                logger.warning(f"[CONFIG] 账户配置为空，请在管理面板添加账户或编辑 {ACCOUNTS_FILE}")
-            return accounts_data
+            import asyncio
+            loop = asyncio.get_event_loop()
+            accounts_data = loop.run_until_complete(storage.load_accounts())
+            if accounts_data is not None:
+                if accounts_data:
+                    logger.info(f"[CONFIG] 从数据库加载配置，共 {len(accounts_data)} 个账户")
+                else:
+                    logger.warning(f"[CONFIG] 数据库中账户配置为空")
+                return accounts_data
         except Exception as e:
-            logger.warning(f"[CONFIG] 文件加载失败: {str(e)}，创建空配置")
+            logger.warning(f"[CONFIG] 数据库加载失败: {e}，降级到文件存储")
 
-    # 文件不存在，创建空配置
-    logger.warning(f"[CONFIG] 未找到 {ACCOUNTS_FILE}，已创建空配置文件")
-    logger.info(f"[CONFIG] 💡 请在管理面板添加账户，或直接编辑 {ACCOUNTS_FILE}，或使用批量上传功能，或设置环境变量 ACCOUNTS_CONFIG")
+    # 3. 从文件加载
+    accounts_data = _load_from_file()
+    if accounts_data is not None:
+        if accounts_data:
+            logger.info(f"[CONFIG] 从文件加载配置: {ACCOUNTS_FILE}，共 {len(accounts_data)} 个账户")
+        else:
+            logger.warning(f"[CONFIG] 账户配置为空，请在管理面板添加账户或编辑 {ACCOUNTS_FILE}")
+        return accounts_data
+
+    # 4. 无配置，创建空配置
+    logger.warning(f"[CONFIG] 未找到配置，已创建空配置")
+    logger.info(f"[CONFIG] 💡 请在管理面板添加账户，或设置 DATABASE_URL 使用数据库存储")
     save_accounts_to_file([])
     return []
 

--- a/core/storage.py
+++ b/core/storage.py
@@ -1,0 +1,192 @@
+"""
+存储抽象层 - 支持文件存储和 PostgreSQL 数据库存储
+
+通过 DATABASE_URL 环境变量自动切换：
+- 未设置：使用本地文件存储（原有逻辑）
+- 已设置：使用 PostgreSQL 数据库存储
+
+示例：
+DATABASE_URL=postgresql://user:pass@host:5432/dbname?sslmode=require
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# 数据库 URL（可选）
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+# 数据库连接池（延迟初始化）
+_db_pool = None
+
+
+def is_database_enabled() -> bool:
+    """检查是否启用数据库存储"""
+    return bool(DATABASE_URL)
+
+
+async def _get_pool():
+    """获取数据库连接池（延迟初始化）"""
+    global _db_pool
+    if _db_pool is None:
+        try:
+            import asyncpg
+            _db_pool = await asyncpg.create_pool(
+                DATABASE_URL,
+                min_size=1,
+                max_size=10,
+                command_timeout=30
+            )
+            # 初始化表结构
+            await _init_tables()
+            logger.info("[STORAGE] PostgreSQL 连接池已创建")
+        except ImportError:
+            logger.error("[STORAGE] 需要安装 asyncpg: pip install asyncpg")
+            raise
+        except Exception as e:
+            logger.error(f"[STORAGE] 数据库连接失败: {e}")
+            raise
+    return _db_pool
+
+
+async def _init_tables():
+    """初始化数据库表结构"""
+    pool = _db_pool
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS kv_store (
+                key TEXT PRIMARY KEY,
+                value JSONB NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        logger.info("[STORAGE] 数据库表已初始化")
+
+
+async def db_get(key: str) -> Optional[dict]:
+    """从数据库获取数据"""
+    pool = await _get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT value FROM kv_store WHERE key = $1", key
+        )
+        if row:
+            return json.loads(row["value"])
+        return None
+
+
+async def db_set(key: str, value: dict):
+    """保存数据到数据库"""
+    pool = await _get_pool()
+    async with pool.acquire() as conn:
+        await conn.execute("""
+            INSERT INTO kv_store (key, value, updated_at)
+            VALUES ($1, $2, CURRENT_TIMESTAMP)
+            ON CONFLICT (key) DO UPDATE SET
+                value = EXCLUDED.value,
+                updated_at = CURRENT_TIMESTAMP
+        """, key, json.dumps(value, ensure_ascii=False))
+
+
+# ==================== 账户存储接口 ====================
+
+async def load_accounts() -> list:
+    """
+    加载账户配置
+    - 优先从环境变量 ACCOUNTS_CONFIG 加载
+    - 其次从数据库加载（如果启用）
+    - 最后从文件加载
+    """
+    # 1. 优先从环境变量加载
+    env_accounts = os.environ.get("ACCOUNTS_CONFIG")
+    if env_accounts:
+        try:
+            accounts = json.loads(env_accounts)
+            logger.info(f"[STORAGE] 从环境变量加载 {len(accounts)} 个账户")
+            return accounts
+        except Exception as e:
+            logger.error(f"[STORAGE] 环境变量解析失败: {e}")
+
+    # 2. 从数据库加载（如果启用）
+    if is_database_enabled():
+        try:
+            data = await db_get("accounts")
+            if data:
+                logger.info(f"[STORAGE] 从数据库加载 {len(data)} 个账户")
+                return data
+            logger.info("[STORAGE] 数据库中无账户数据")
+            return []
+        except Exception as e:
+            logger.error(f"[STORAGE] 数据库读取失败: {e}")
+            # 降级到文件存储
+    
+    # 3. 从文件加载（原有逻辑）
+    return None  # 返回 None 表示使用原有文件加载逻辑
+
+
+async def save_accounts(accounts: list):
+    """
+    保存账户配置
+    - 如果启用数据库，保存到数据库
+    - 否则保存到文件
+    """
+    if is_database_enabled():
+        try:
+            await db_set("accounts", accounts)
+            logger.info(f"[STORAGE] 已保存 {len(accounts)} 个账户到数据库")
+            return True
+        except Exception as e:
+            logger.error(f"[STORAGE] 数据库写入失败: {e}")
+            # 降级到文件存储
+    
+    return False  # 返回 False 表示使用原有文件保存逻辑
+
+
+# ==================== 设置存储接口 ====================
+
+async def load_settings() -> Optional[dict]:
+    """从数据库加载设置（如果启用）"""
+    if is_database_enabled():
+        try:
+            return await db_get("settings")
+        except Exception as e:
+            logger.error(f"[STORAGE] 设置读取失败: {e}")
+    return None
+
+
+async def save_settings(settings: dict) -> bool:
+    """保存设置到数据库（如果启用）"""
+    if is_database_enabled():
+        try:
+            await db_set("settings", settings)
+            logger.info("[STORAGE] 设置已保存到数据库")
+            return True
+        except Exception as e:
+            logger.error(f"[STORAGE] 设置写入失败: {e}")
+    return False
+
+
+# ==================== 统计存储接口 ====================
+
+async def load_stats() -> Optional[dict]:
+    """从数据库加载统计数据（如果启用）"""
+    if is_database_enabled():
+        try:
+            return await db_get("stats")
+        except Exception as e:
+            logger.error(f"[STORAGE] 统计读取失败: {e}")
+    return None
+
+
+async def save_stats(stats: dict) -> bool:
+    """保存统计数据到数据库（如果启用）"""
+    if is_database_enabled():
+        try:
+            await db_set("stats", stats)
+            return True
+        except Exception as e:
+            logger.error(f"[STORAGE] 统计写入失败: {e}")
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ itsdangerous==2.1.2
 python-multipart==0.0.6
 pyyaml>=6.0
 jinja2>=3.1.0
+
+# 可选：PostgreSQL 数据库支持（用于 HF Spaces 等无持久化存储的环境）
+# 如需使用，请取消下行注释并设置 DATABASE_URL 环境变量
+# asyncpg>=0.29.0


### PR DESCRIPTION
## 功能
添加可选的 PostgreSQL 数据库存储支持，适用于 HF Spaces 等无持久化存储的环境。

## 动机
在 HuggingFace Spaces 免费版部署时，文件存储会在重启后丢失。通过支持外部数据库（如 Neon PostgreSQL），可以实现账户配置的持久化存储。

## 改动
- 新增 `core/storage.py` - 存储抽象层，自动切换文件/数据库存储
- 修改 `core/account.py` - 使用存储层（完全向后兼容）
- 更新 `requirements.txt` - 添加可选依赖说明
- 更新 `.env.example` - 添加 DATABASE_URL 配置说明

## 使用方法
设置环境变量即可启用：

DATABASE_URL=postgresql://user:pass@host/db?sslmode=require

未设置时保持原有文件存储行为，完全向后兼容。

## 特性
- ✅ 完全向后兼容 - 未设置 DATABASE_URL 时行为不变
- ✅ 自动降级 - 数据库连接失败时自动使用文件存储
- ✅ 最小侵入 - 原有代码改动极少，便于合并上游更新