### PR TITLE
feat: 添加自动刷新账号功能（解决数据库新增账号无法自动识别问题）

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -52,6 +52,7 @@ class RetryConfig(BaseModel):
     account_failure_threshold: int = Field(default=3, ge=1, le=10, description="账户失败阈值")
     rate_limit_cooldown_seconds: int = Field(default=600, ge=60, le=3600, description="429冷却时间（秒）")
     session_cache_ttl_seconds: int = Field(default=3600, ge=300, le=86400, description="会话缓存时间（秒）")
+    auto_refresh_accounts_seconds: int = Field(default=60, ge=0, le=600, description="自动刷新账号间隔（秒，0禁用）")
 
 
 class PublicDisplayConfig(BaseModel):
@@ -281,6 +282,11 @@ class ConfigManager:
     def session_cache_ttl_seconds(self) -> int:
         """会话缓存时间（秒）"""
         return self._config.retry.session_cache_ttl_seconds
+
+    @property
+    def auto_refresh_accounts_seconds(self) -> int:
+        """自动刷新账号间隔（秒，0禁用）"""
+        return self._config.retry.auto_refresh_accounts_seconds
 
 
 # ==================== 全局配置管理器 ====================

--- a/core/storage.py
+++ b/core/storage.py
@@ -159,6 +159,28 @@ async def load_accounts() -> Optional[list]:
     return None
 
 
+async def get_accounts_count() -> Optional[int]:
+    """
+    Get the number of accounts in the database (lightweight check).
+    Return None if database is not enabled or failed.
+    """
+    if not is_database_enabled():
+        return None
+    try:
+        data = await db_get("accounts")
+        if data:
+            return len(data)
+        return 0
+    except Exception as e:
+        logger.error(f"[STORAGE] Database accounts count failed: {e}")
+    return None
+
+
+def get_accounts_count_sync() -> Optional[int]:
+    """Sync wrapper for get_accounts_count."""
+    return _run_in_db_loop(get_accounts_count())
+
+
 async def save_accounts(accounts: list) -> bool:
     """Save account configuration to database when enabled."""
     if not is_database_enabled():


### PR DESCRIPTION
## 问题描述

当使用数据库存储账号配置时，如果通过外部工具（如 geminib）向数据库添加新账号，HF 项目需要手动刷新或重启空间才能识别新账号。这对于需要频繁添加账号的场景非常不便。

## 解决方案

添加一个后台任务，定期检查数据库中的账号数量变化，发现变化时自动重新加载账号配置。

## 修改内容

### 1. `core/storage.py`
- 添加 `get_accounts_count()` 异步函数：轻量级获取数据库中账号数量
- 添加 `get_accounts_count_sync()` 同步包装函数

### 2. `core/config.py`
- 添加 `auto_refresh_accounts_seconds` 配置项
  - 默认值：60秒
  - 范围：0-600秒（0表示禁用）
  - 描述：自动刷新账号间隔

### 3. `main.py`
- 添加 `auto_refresh_accounts_task()` 后台任务函数
- 在 `startup_event()` 中启动自动刷新任务（仅数据库模式有效）

## 功能特点

- ✅ **自动检测变化**：定期检查数据库中的账号数量
- ✅ **无缝刷新**：检测到变化后自动重载，保留现有账号的运行时状态
- ✅ **可配置**：通过 `retry.auto_refresh_accounts_seconds` 设置间隔
- ✅ **支持热更新**：刷新间隔配置支持运行时修改
- ✅ **低开销**：仅在数据库模式下启用，只检查账号数量

## 配置示例

在 `settings.yaml` 中配置：
```yaml
retry:
  auto_refresh_accounts_seconds: 60  # 每60秒检查一次，设为0禁用