### PR TITLE
Fix Python 3.12 compatibility with uv and Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿<p align="center">
+<p align="center">
   <img src="docs/logo.svg" width="120" alt="Gemini Business2API logo" />
 </p>
 <h1 align="center">Gemini Business2API</h1>
@@ -7,7 +7,7 @@
 <p align="center">
   <strong>简体中文</strong> | <a href="docs/README_EN.md">English</a>
 </p>
-<p align="center"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" /> <img src="https://img.shields.io/badge/Python-3.11+-3776AB?logo=python&logoColor=white" /> <img src="https://img.shields.io/badge/FastAPI-0.110-009688?logo=fastapi&logoColor=white" /> <img src="https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js&logoColor=white" /> <img src="https://img.shields.io/badge/Vite-7-646CFF?logo=vite&logoColor=white" /> <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" /></p>
+<p align="center"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" /> <img src="https://img.shields.io/badge/Python-3.11-3776AB?logo=python&logoColor=white" /> <img src="https://img.shields.io/badge/FastAPI-0.110-009688?logo=fastapi&logoColor=white" /> <img src="https://img.shields.io/badge/Vue-3-4FC08D?logo=vue.js&logoColor=white" /> <img src="https://img.shields.io/badge/Vite-7-646CFF?logo=vite&logoColor=white" /> <img src="https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white" /></p>
 
 <p align="center">
   <a href="https://huggingface.co/spaces/xiaoyukkkk/gemini-business2api?duplicate=true">
@@ -70,15 +70,23 @@
 
 ## 🚀 快速开始
 
+### 前置要求
+
+- **Python 3.11**（必需，项目使用 uv 自动管理 Python 版本）
+- **Git**
+- **Node.js & npm**（用于构建前端）
+- **uv**（安装脚本会自动安装）
+
+> **⚠️ 注意**：Python 3.12 不支持，因为部分依赖使用 `distutils`（Python 3.12 已移除）。安装脚本会自动下载并安装 Python 3.11，无需手动安装。
+
 ### 方式一：使用安装脚本（推荐）
 
-**Linux/macOS:**
+**Linux/macOS (WSL):**
 ```bash
 git clone https://github.com/Dreamy-rain/gemini-business2api.git
 cd gemini-business2api
 bash setup.sh
 
-cp .env.example .env
 # 编辑 .env 设置 ADMIN_KEY
 
 source .venv/bin/activate  # Linux/macOS
@@ -87,7 +95,6 @@ source .venv/bin/activate  # Linux/macOS
 python main.py
 
 # pm2后台运行
-# 确保你在项目目录下
 pm2 start main.py --name gemini-api --interpreter ./.venv/bin/python3
 ```
 
@@ -97,7 +104,6 @@ git clone https://github.com/Dreamy-rain/gemini-business2api.git
 cd gemini-business2api
 setup.bat
 
-copy .env.example .env
 # 编辑 .env 设置 ADMIN_KEY
 
 source .venv/bin/activate  # Linux/macOS
@@ -106,11 +112,12 @@ source .venv/bin/activate  # Linux/macOS
 python main.py
 
 # pm2后台运行
-# 确保你在项目目录下
-pm2 start main.py --name gemini-api --interpreter ./.venv/bin/python3
+pm2 start main.py --name gemini-api --interpreter ./.venv/Scripts/python.exe
 ```
 
-**脚本功能：**
+**安装脚本功能：**
+- ✅ 自动安装/更新 uv（现代 Python 包管理器）
+- ✅ 自动下载并安装 Python 3.11（如果系统中没有）
 - ✅ 自动同步最新代码
 - ✅ 更新前端到最新版本
 - ✅ 创建/更新 Python 虚拟环境
@@ -119,7 +126,7 @@ pm2 start main.py --name gemini-api --interpreter ./.venv/bin/python3
 
 **首次安装：** 完成后编辑 `.env` 设置 `ADMIN_KEY`，然后运行 `python main.py`
 
-**更新项目：** 直接运行相同命令即可，脚本会自动更新所有组件（代码、依赖、前端）
+**更新项目：** 直接运行相同命令即可，脚本会自动更新所有组件（代码、依赖、前端、Python 环境）
 
 ### 方式二：手动部署
 
@@ -127,26 +134,32 @@ pm2 start main.py --name gemini-api --interpreter ./.venv/bin/python3
 git clone https://github.com/Dreamy-rain/gemini-business2api.git
 cd gemini-business2api
 
+# 安装 uv（必需）
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 安装 Python 3.11（必需）
+uv python install 3.11
+
 # 构建前端
 cd frontend
 npm install
 npm run build
 cd ..
 
-# 创建虚拟环境（推荐）
-python3 -m venv .venv
+# 创建虚拟环境
+uv venv --python 3.11 .venv
 source .venv/bin/activate  # Linux/macOS
 # .venv\Scripts\activate.bat  # Windows
 
 # 安装 Python 依赖
-pip install -r requirements.txt
+uv pip install -r requirements.txt
+
 cp .env.example .env
-# win copy .env.example .env
+# win: copy .env.example .env
 # 编辑 .env 设置 ADMIN_KEY
 python main.py
 
 # pm2后台运行
-# 确保你在项目目录下
 pm2 start main.py --name gemini-api --interpreter ./.venv/bin/python3
 ```
 
@@ -247,6 +260,3 @@ docker-compose pull && docker-compose up -d
 [![Star History Chart](https://api.star-history.com/svg?repos=Dreamy-rain/gemini-business2api&type=date&legend=top-left)](https://www.star-history.com/#Dreamy-rain/gemini-business2api&type=date&legend=top-left)
 
 **如果这个项目对你有帮助，请给个 ⭐ Star!**
-
-
-

--- a/setup.bat
+++ b/setup.bat
@@ -1,6 +1,7 @@
 @echo off
 REM Gemini Business2API Setup Script
 REM Handles both installation and updates automatically
+REM Uses uv for Python environment management
 REM Usage: setup.bat
 
 setlocal enabledelayedexpansion
@@ -10,6 +11,19 @@ echo Gemini Business2API Setup Script
 echo ==========================================
 echo.
 
+REM Color codes for output (using echo instead of ANSI codes for better Windows compatibility)
+set GREEN=[92m
+set RED=[91m
+set YELLOW=[93m
+set BLUE=[94m
+set NC=[0m
+
+REM Function to print colored messages (simplified for Windows)
+set "PRINT_SUCCESS=echo [SUCCESS]"
+set "PRINT_ERROR=echo [ERROR]"
+set "PRINT_INFO=echo [INFO]"
+set "PRINT_STEP=echo [STEP]"
+
 REM Check if git is installed
 where git >nul 2>nul
 if %errorlevel% neq 0 (
@@ -17,15 +31,52 @@ if %errorlevel% neq 0 (
     exit /b 1
 )
 
-REM Check if python is installed
-where python >nul 2>nul
-if %errorlevel% neq 0 (
-    echo [ERROR] Python is not installed. Please install Python 3.11+ first.
-    exit /b 1
-)
+REM Step 1: Install or update uv
+echo [STEP] Step 1: Installing/Updating uv...
 
-REM Step 1: Pull latest code from git
-echo [STEP] Step 1: Syncing code from repository...
+where uv >nul 2>nul
+if %errorlevel% neq 0 (
+    echo [INFO] uv not found, installing...
+    REM Install uv using pipx or pip
+    pipx install uv 2>nul
+    if %errorlevel% neq 0 (
+        pip install --user uv 2>nul
+        if %errorlevel% neq 0 (
+            REM Fallback: download and install uv binary
+            curl -LsSf https://astral.sh/uv/install.bat | cmd
+        )
+    )
+    if %errorlevel% equ 0 (
+        echo [SUCCESS] uv installed successfully
+    ) else (
+        echo [ERROR] Failed to install uv
+        exit /b 1
+    )
+) else (
+    echo [INFO] Updating uv to latest version...
+    uv pip install --upgrade uv
+    echo [SUCCESS] uv updated
+)
+echo.
+
+REM Step 2: Ensure Python 3.11 is available
+echo [STEP] Step 2: Ensuring Python 3.11 is available...
+uv python list | findstr /C:"3.11" >nul
+if %errorlevel% neq 0 (
+    echo [INFO] Python 3.11 not found, installing...
+    uv python install 3.11
+    if %errorlevel% neq 0 (
+        echo [ERROR] Failed to install Python 3.11
+        exit /b 1
+    )
+    echo [SUCCESS] Python 3.11 installed
+) else (
+    echo [SUCCESS] Python 3.11 is already available
+)
+echo.
+
+REM Step 3: Pull latest code from git
+echo [STEP] Step 3: Syncing code from repository...
 echo [INFO] Fetching latest changes...
 git fetch origin
 
@@ -38,8 +89,8 @@ if %errorlevel% equ 0 (
 )
 echo.
 
-REM Step 2: Setup .env file if it doesn't exist
-echo [STEP] Step 2: Checking configuration...
+REM Step 4: Setup .env file if it doesn't exist
+echo [STEP] Step 4: Checking configuration...
 if exist .env (
     echo [INFO] .env file exists
 ) else (
@@ -54,32 +105,35 @@ if exist .env (
 )
 echo.
 
-REM Step 3: Setup Python virtual environment
-echo [STEP] Step 3: Setting up Python environment...
+REM Step 5: Setup Python virtual environment
+echo [STEP] Step 5: Setting up Python environment...
 if exist .venv (
     echo [INFO] Virtual environment already exists
 ) else (
-    echo [INFO] Creating virtual environment...
-    python -m venv .venv
+    echo [INFO] Creating virtual environment with Python 3.11...
+    uv venv --python 3.11 .venv
+    if %errorlevel% neq 0 (
+        echo [ERROR] Failed to create virtual environment
+        exit /b 1
+    )
     echo [SUCCESS] Virtual environment created
 )
-
-echo [INFO] Activating virtual environment...
-call .venv\Scripts\activate.bat
-
-echo [INFO] Upgrading pip...
-python -m pip install --upgrade pip --quiet
-echo [SUCCESS] Pip upgraded
 echo.
 
-REM Step 4: Install/Update Python dependencies
-echo [STEP] Step 4: Installing Python dependencies...
-pip install -r requirements.txt --upgrade
+REM Step 6: Install/Update Python dependencies
+echo [STEP] Step 6: Installing Python dependencies...
+echo [INFO] Using uv to install dependencies (this may take a moment)...
+.venv\Scripts\python.exe -m pip install --upgrade pip --quiet
+uv pip install -r requirements.txt
+if %errorlevel% neq 0 (
+    echo [ERROR] Failed to install Python dependencies
+    exit /b 1
+)
 echo [SUCCESS] Python dependencies installed
 echo.
 
-REM Step 5: Setup frontend
-echo [STEP] Step 5: Setting up frontend...
+REM Step 7: Setup frontend
+echo [STEP] Step 7: Setting up frontend...
 if exist frontend (
     cd frontend
 
@@ -87,10 +141,10 @@ if exist frontend (
     where npm >nul 2>nul
     if %errorlevel% equ 0 (
         echo [INFO] Installing dependencies...
-        call npm install
+        npm install
 
         echo [INFO] Building frontend...
-        call npm run build
+        npm run build
         echo [SUCCESS] Frontend built successfully
     ) else (
         echo [ERROR] npm is not installed. Please install Node.js and npm first.
@@ -105,7 +159,7 @@ if exist frontend (
 )
 echo.
 
-REM Step 6: Show completion message
+REM Step 8: Show completion message
 echo ==========================================
 echo [SUCCESS] Setup completed successfully!
 echo ==========================================
@@ -118,7 +172,7 @@ if exist .env (
     echo      notepad .env
     echo.
     echo   2. Start the service:
-    echo      python main.py
+    echo      .venv\Scripts\python.exe main.py
     echo.
     echo   3. Access the admin panel:
     echo      http://localhost:7860/


### PR DESCRIPTION
Fixes #20

Python 3.12 removed distutils, breaking some dependencies. This PR:
- Locks Python to 3.11
- Uses uv for faster package management
- Auto-installs uv and Python 3.11 in setup scripts