### PR TITLE
fix: 统一代理解析并修复 NO_PROXY 热更新问题

### DIFF
--- a/core/login_service.py
+++ b/core/login_service.py
@@ -14,6 +14,7 @@ from core.mail_providers import create_temp_mail_client
 from core.gemini_automation import GeminiAutomation
 from core.gemini_automation_uc import GeminiAutomationUC
 from core.microsoft_mail_client import MicrosoftMailClient
+from core.proxy_utils import parse_proxy_setting
 
 logger = logging.getLogger("gemini.login")
 
@@ -191,6 +192,7 @@ class LoginService(BaseTaskService[LoginTask]):
         mail_client_id = account.get("mail_client_id")
         mail_refresh_token = account.get("mail_refresh_token")
         mail_tenant = account.get("mail_tenant") or "consumers"
+        proxy_for_auth, _ = parse_proxy_setting(config.basic.proxy_for_auth)
 
         def log_cb(level, message):
             self._append_log(task, level, f"[{account_id}] {message}")
@@ -206,7 +208,7 @@ class LoginService(BaseTaskService[LoginTask]):
                 client_id=mail_client_id,
                 refresh_token=mail_refresh_token,
                 tenant=mail_tenant,
-                proxy=config.basic.proxy_for_auth,
+                proxy=proxy_for_auth,
                 log_callback=log_cb,
             )
             client.set_credentials(mail_address)
@@ -255,7 +257,7 @@ class LoginService(BaseTaskService[LoginTask]):
             # DrissionPage 引擎：支持有头和无头模式
             automation = GeminiAutomation(
                 user_agent=self.user_agent,
-                proxy=config.basic.proxy_for_auth,
+                proxy=proxy_for_auth,
                 headless=headless,
                 log_callback=log_cb,
             )
@@ -266,7 +268,7 @@ class LoginService(BaseTaskService[LoginTask]):
                 headless = False
             automation = GeminiAutomationUC(
                 user_agent=self.user_agent,
-                proxy=config.basic.proxy_for_auth,
+                proxy=proxy_for_auth,
                 headless=headless,
                 log_callback=log_cb,
             )

--- a/core/mail_providers/factory.py
+++ b/core/mail_providers/factory.py
@@ -26,8 +26,10 @@ def create_temp_mail_client(
     """
     provider = (provider or "duckmail").lower()
     if proxy is None:
-        proxy = config.basic.proxy_for_auth if config.basic.mail_proxy_enabled else ""
-    proxy, no_proxy = parse_proxy_setting(proxy if config.basic.mail_proxy_enabled else "")
+        proxy_source = config.basic.proxy_for_auth if config.basic.mail_proxy_enabled else ""
+    else:
+        proxy_source = proxy
+    proxy, no_proxy = parse_proxy_setting(proxy_source)
 
     if provider == "moemail":
         effective_base_url = base_url or config.basic.moemail_base_url

--- a/core/proxy_utils.py
+++ b/core/proxy_utils.py
@@ -53,7 +53,7 @@ def parse_proxy_setting(proxy_str: str) -> Tuple[str, str]:
         if no_proxy_match:
             no_proxy = no_proxy_match.group(1).strip()
 
-    return proxy_url, no_proxy
+    return normalize_proxy_url(proxy_url), no_proxy
 
 
 def extract_host(url: str) -> str:

--- a/core/register_service.py
+++ b/core/register_service.py
@@ -12,6 +12,7 @@ from core.config import config
 from core.mail_providers import create_temp_mail_client
 from core.gemini_automation import GeminiAutomation
 from core.gemini_automation_uc import GeminiAutomationUC
+from core.proxy_utils import parse_proxy_setting
 
 logger = logging.getLogger("gemini.register")
 
@@ -200,6 +201,7 @@ class RegisterService(BaseTaskService[RegisterTask]):
         # 根据配置选择浏览器引擎
         browser_engine = (config.basic.browser_engine or "dp").lower()
         headless = config.basic.browser_headless
+        proxy_for_auth, _ = parse_proxy_setting(config.basic.proxy_for_auth)
 
         log_cb("info", f"🌐 步骤 2/3: 启动浏览器 (引擎={browser_engine}, 无头模式={headless})...")
 
@@ -207,7 +209,7 @@ class RegisterService(BaseTaskService[RegisterTask]):
             # DrissionPage 引擎：支持有头和无头模式
             automation = GeminiAutomation(
                 user_agent=self.user_agent,
-                proxy=config.basic.proxy_for_auth,
+                proxy=proxy_for_auth,
                 headless=headless,
                 log_callback=log_cb,
             )
@@ -218,7 +220,7 @@ class RegisterService(BaseTaskService[RegisterTask]):
                 headless = False
             automation = GeminiAutomationUC(
                 user_agent=self.user_agent,
-                proxy=config.basic.proxy_for_auth,
+                proxy=proxy_for_auth,
                 headless=headless,
                 log_callback=log_cb,
             )

--- a/main.py
+++ b/main.py
@@ -357,6 +357,8 @@ PROXY_FOR_CHAT = _proxy_chat
 _NO_PROXY = ",".join(filter(None, {_no_proxy_auth, _no_proxy_chat}))
 if _NO_PROXY:
     os.environ["NO_PROXY"] = _NO_PROXY
+else:
+    os.environ.pop("NO_PROXY", None)
 BASE_URL = config.basic.base_url
 SESSION_SECRET_KEY = config.security.session_secret_key
 SESSION_EXPIRE_HOURS = config.session.expire_hours
@@ -1577,6 +1579,8 @@ async def admin_update_settings(request: Request, new_settings: dict = Body(...)
         _NO_PROXY = ",".join(filter(None, {_no_proxy_auth, _no_proxy_chat}))
         if _NO_PROXY:
             os.environ["NO_PROXY"] = _NO_PROXY
+        else:
+            os.environ.pop("NO_PROXY", None)
         BASE_URL = config.basic.base_url
         LOGO_URL = config.public_display.logo_url
         CHAT_URL = config.public_display.chat_url


### PR DESCRIPTION
## 变更说明
- 在 `core/proxy_utils.py` 中统一代理解析逻辑：`parse_proxy_setting` 会将 `host:port` 和旧格式标准化为可用代理 URL。
- 修复注册/刷新链路中代理透传问题：避免将包含 `| no_proxy=...` 的复合字符串直接传给 Microsoft 邮箱与浏览器自动化。
- 修复临时邮箱工厂的代理优先级：显式传入 `proxy` 时，保持“传入参数优先”，不再被 `mail_proxy_enabled` 覆盖。
- 修复 `NO_PROXY` 热更新残留：当配置清空时会删除环境变量，避免旧绕过规则持续生效。

## 校验
- `python -m py_compile core/proxy_utils.py core/mail_providers/factory.py core/login_service.py core/register_service.py main.py`