### PR TITLE
refactor: move health check endpoint from /admin/health to /health

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ EXPOSE 7860
 
 # 健康检查
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:7860/admin/health || exit 1
+    CMD curl -f http://localhost:7860/health || exit 1
 
 # 启动服务
 CMD ["./entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
     # 健康检查
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7860/admin/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:7860/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -16,5 +16,5 @@ export const authApi = {
     apiClient.post('/logout'),
 
   checkAuth: () =>
-    apiClient.get('/admin/health'),
+    apiClient.get('/health'),
 }

--- a/main.py
+++ b/main.py
@@ -652,7 +652,7 @@ async def serve_logo():
         return FileResponse(logo_path)
     raise HTTPException(404, "Not Found")
 
-@app.get("/admin/health")
+@app.get("/health")
 async def health_check():
     """健康检查端点，用于 Docker HEALTHCHECK"""
     return {"status": "ok"}


### PR DESCRIPTION
## Summary

Move the health check endpoint from `/admin/health` to `/health` to follow industry conventions.

## Changes

- **main.py**: Update route from `/admin/health` to `/health`
- **Dockerfile**: Update HEALTHCHECK URL
- **docker-compose.yml**: Update healthcheck URL
- **frontend/src/api/auth.ts**: Update `checkAuth` call URL

## Motivation

`/health` is the standard path expected by load balancers, Kubernetes probes, and other infrastructure tooling. This makes the service easier to integrate without custom configuration.